### PR TITLE
adding OEM build date

### DIFF
--- a/check_versions.sh
+++ b/check_versions.sh
@@ -74,5 +74,7 @@ if [ -f omni.ja ] && [ -f application.zip ] && [ -f application.ini ]; then
 	done
 fi
 
+adb shell cat /system/build.prop | grep "ro.build.version.incremental"
+
 rm -rf $dir
 


### PR DESCRIPTION
Adding the OEM build date, so we have a better idea which base build is being used.

We could get the build id from the build.prop.... ( ro.build.version.incremental= )
Not sure which is preferred.
