### PR TITLE
show the OEM build date as well

### DIFF
--- a/check_versions.sh
+++ b/check_versions.sh
@@ -74,7 +74,8 @@ if [ -f omni.ja ] && [ -f application.zip ] && [ -f application.ini ]; then
 	done
 fi
 
-adb shell cat /system/build.prop | grep "ro.build.version.incremental"
+adb shell cat /system/build.prop | grep 'ro.build.version.incremental'
+adb shell cat /system/build.prop | grep 'ro.build.date='
 
 rm -rf $dir
 


### PR DESCRIPTION
They changed the ro.build.version.incremental to no longer have the build id ; 
adding the build date so that it makes it easier to tell when the OEM build was created.
