### PR TITLE
Fixed zip file name for 1.4 flame

### DIFF
--- a/.PVT_DL_LIST.conf
+++ b/.PVT_DL_LIST.conf
@@ -228,12 +228,12 @@ DL_20_ENG_GECKO=b2g-28.1.en-US.android-arm.tar.gz
 
 DL_21_NAME=PVT.v140.flame
 DL_21_URL=https://pvtbuilds.mozilla.org/pvt/mozilla.org/b2gotoro/nightly/mozilla-b2g30_v1_4-flame/latest/
-DL_21_IMG=unagi.zip
+DL_21_IMG=flame.zip
 DL_21_GAIA=gaia.zip
 DL_21_GECKO=b2g-30.0.en-US.android-arm.tar.gz
 DL_21_ENG=true
 DL_21_ENG_URL=https://pvtbuilds.mozilla.org/pvt/mozilla.org/b2gotoro/nightly/mozilla-b2g30_v1_4-flame-eng/latest/
-DL_21_ENG_IMG=unagi.zip
+DL_21_ENG_IMG=flame.zip
 DL_21_ENG_GAIA=gaia.zip
 DL_21_ENG_GECKO=b2g-30.0.en-US.android-arm.tar.gz
 


### PR DESCRIPTION
This fixes that flashing a flame with 1.4 fails

```
Download file: https://pvtbuilds.mozilla.org/pvt/mozilla.org/b2gotoro/nightly/mozilla-b2g30_v1_4-flame/latest/unagi.zip
./auto_flash_from_pvt.sh: line 287: .ldap: No such file or directory
WGET:  -P pvt/flame/v140/USR/latest https://pvtbuilds.mozilla.org/pvt/mozilla.org/b2gotoro/nightly/mozilla-b2g30_v1_4-flame/latest/unagi.zip
--2014-05-07 10:11:22--  https://pvtbuilds.mozilla.org/pvt/mozilla.org/b2gotoro/nightly/mozilla-b2g30_v1_4-flame/latest/unagi.zip
Resolving pvtbuilds.mozilla.org... 63.245.215.32
Connecting to pvtbuilds.mozilla.org|63.245.215.32|:443... connected.
HTTP request sent, awaiting response... 401 Authorization Required
Reusing existing connection to pvtbuilds.mozilla.org:443.
HTTP request sent, awaiting response... 404 Not Found
2014-05-07 10:11:25 ERROR 404: Not Found.
```
