### PR TITLE
fix the url for master flame to be user build instead of eng

### DIFF
--- a/.PVT_DL_LIST.conf
+++ b/.PVT_DL_LIST.conf
@@ -362,7 +362,7 @@ DL_33_GECKO=b2g-32.0a1.en-US.android-arm.tar.gz
 DL_33_ENG=false
 
 DL_34_NAME=PVT.master.flame
-DL_34_URL=https://pvtbuilds.mozilla.org/pvt/mozilla.org/b2gotoro/nightly/mozilla-central-flame-eng/latest/
+DL_34_URL=https://pvtbuilds.mozilla.org/pvt/mozilla.org/b2gotoro/nightly/mozilla-central-flame/latest/
 DL_34_IMG=flame.zip
 DL_34_GAIA=gaia.zip
 DL_34_GECKO=b2g-32.0a1.en-US.android-arm.tar.gz


### PR DESCRIPTION
URL is wrong for flame user build.  Correcting.
