### PR TITLE
Important improvements to the B2G backup and restore tool

### DIFF
--- a/backup_restore_profile.sh
+++ b/backup_restore_profile.sh
@@ -29,8 +29,8 @@ function run_adb()
 }
 
 function do_backup_profile() {
-    profile_dir=$1 ; shift
-    do_reboot=$1 ; shift
+    local profile_dir=$1 ; shift
+    local do_reboot=$1 ; shift
     # GNU mktemp has a nice --tmpdir option, but not so on OS X
     tmp_dir=$(TMPDIR=. mktemp -d -t "$(basename $profile_dir).XXXXXXXXXX")
     log "Stoping B2G..."
@@ -63,8 +63,8 @@ function do_backup_profile() {
 }
 
 function do_restore_profile() {
-    profile_dir=$1 ; shift
-    do_reboot=$1 ; shift
+    local profile_dir=$1 ; shift
+    local do_reboot=$1 ; shift
     log "Recover your profile..."
     if [ ! -d ${profile_dir}/profile ] || [ ! -d ${profile_dir}/data-local ]; then
         log "No recover files in ${profile_dir}."


### PR DESCRIPTION
There are a couple issues here:
- Error codes aren't checked anywhere.  This means that if the first ADB call fails, we try the second one.  This is compounded by the next issue
- The previous backup is deleted before we've created a new one.  This means that we could be deleting a good backup to replace with junk.
- Getopt is called and some of the output is read, in some interesting way, but the argument handling is redone in an infinite loop that's really hard to understand and has different behaviour depending on where the arguments are in the argv
- Exit codes are generated by this script in too many places and are wrong.  Exit code 0 in the helper function meant that at least one exit 1 never actually exited with 1
- Log handling has a lot of boiler plate on each line.

I've addressed all of these issues.  The only major change that I've made is that the log file is now a single file in the directory where the backup is run which accumulates command output into a single log file.  This file can be changed with the LOGFILE environment variable.

A couple features that I think this script should have:
- Backups should be in a subdirectory of the current directory, e.g. firefoxos-backups/2014/07-06, and the latest one should be used by default
- It should be possible to save the backups in compressed tarballs or hg/git to reduce size
