### PR TITLE
Fixed issues with bad Cygwin conditions on non-windows system

### DIFF
--- a/shallow_flash.sh
+++ b/shallow_flash.sh
@@ -136,7 +136,10 @@ function adb_push_gaia() {
     GAIA_DIR=$1
     ## Adjusting user.js
     cat $GAIA_DIR/gaia/profile/user.js | sed -e "s/user_pref/pref/" > $GAIA_DIR/user.js &&
-    if [[ `uname`="CYGWIN"* ]]; then
+    if [[ `uname` == "CYGWIN"* ]]; then
+        if [[ ! -d "/cygdrive/c/tmp" ]]; then
+            mkdir "/cygdrive/c/tmp"
+        fi
         cp -r $GAIA_DIR /cygdrive/c/tmp/
     fi &&
 
@@ -214,7 +217,7 @@ function shallow_flash_gecko() {
 
 	## push gecko into device
     untar_file $GECKO_TAR_FILE $TMP_DIR &&
-    if [[ `uname`="CYGWIN"* ]]; then
+    if [[ `uname` == "CYGWIN"* ]]; then
         cp -r $TMP_DIR /cygdrive/c/tmp/
     fi &&
     echo "### Pushing Gecko to device..." &&


### PR DESCRIPTION
Sorry for mistakes in my last pullrequest, some of them I didn't realized until someone else tried it.
Two fixes here:
- fixed from if conditions for cygwin case  (throwing unnecessary errors for linux/osx user)
- added explicit creation on /tmp dir on windows system (because it is not standard)
