### PR TITLE
Fix the rule of OTA channel update base on Bug 918068.

### DIFF
--- a/change_ota_channel_pref.sh
+++ b/change_ota_channel_pref.sh
@@ -10,10 +10,6 @@ set -e
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    "-d")
-      DEVICE="$2"
-      shift
-      ;;
     "-v")
       VERSION="$2"
       shift
@@ -21,8 +17,7 @@ while [ $# -gt 0 ]; do
     "-h")
       echo "
       Help:
-          -d <device>  : specify a device (leo, tarako, hamachi, helix, inari, flame) to update
-          -v <version> : version to update to (2.1.0, 2.0.0, 1.5.0, 1.4.0, 1.3.0t, 1.3.0, 1.2.0, 1.1.1)
+          -v <version> : version to update to (master, 2.0.0, 1.4.0)
           -h : this help menu
       "
       ;;
@@ -32,49 +27,20 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-case "$DEVICE" in
-  "leo")
-    ;;
-  "hamachi")
-    ;;
-  "helix")
-    ;;
-  "inari")
-    ;;
-  "tarako")
-    ;;
-  "flame")
-    ;;
-  *)
-    echo "You must specify a device: leo, hamachi, helix, inari or flame"
-    exit
-    ;;
-esac
-
 case "$VERSION" in
-  "2.1.0")
-    ;;
+  "master")
+    CHANNEL="night";;
   "2.0.0")
-    ;;
-  "1.5.0")
-    ;;
+    CHANNEL="night-b2g32";;
   "1.4.0")
-    ;;
-  "1.3.0")
-    ;;
-  "1.3.0t")
-    ;;
-  "1.2.0")
-    ;;
-  "1.1.1")
-    ;;
+    CHANNEL="night-b2g30";;
   *)
-    echo "You must specify a version : 2.1.0, 2.0.0, 1.5.0, 1.4.0, 1.3.0t, 1.3.0, 1.2.0, 1.1.1 (1.1.1 for 1.1hd)"
+    echo "You must specify a version : master, 2.0.0, 1.4.0"
     exit
     ;;
 esac
 
-UPDATE_CHANNEL=${UPDATE_CHANNEL:-$DEVICE/$VERSION/nightly}
+UPDATE_CHANNEL=${UPDATE_CHANNEL:-$CHANNEL}
 
 ADB=${ADB:-adb}
 $ADB wait-for-device


### PR DESCRIPTION
ref: #247

```
mozilla-central (master): night
mozilla-b2g32_v2_0 (2.0): nightly-b2g32
mozilla-b2g30_v1_4 (1.4): nightly-b2g30
v1.3 and lower: not supported
```
