### PR TITLE
Added SD card support for backup_restore_profile.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ version
 b2g*
 gaia*
 mozilla-profile/*
+backup_restore_profile.log
 crashreports.txt
 user.js
 size.txt


### PR DESCRIPTION
fix #264 

`./backup_restore_profile.sh -b --sdcard` for backup, and
`./backup_restore_profile.sh -r --sdcard` for recover.

The `/sdcard` folder is for older B2G, and `/storage/sdcard*` is for newer version.
