### PR TITLE
Fix on file rights suggested by jweathersby@mozilla.com

### DIFF
--- a/shallow_flash.sh
+++ b/shallow_flash.sh
@@ -417,6 +417,7 @@ fi
 
 ## Hack for windows with cygwin for permission issue
 ## should use the correct permission instead of 777
+## TODO: resolve in some better way in the future?
 if [[ `uname` == "CYGWIN"* ]]; then
     run_adb shell chmod 777 /system/b2g/b2g
     run_adb shell chmod 777 /system/b2g/updater


### PR DESCRIPTION
which finally makes shallow_flash.sh fully working on Cygwin as well, great... Tested twice.
