### PR TITLE
Bug1069468 fixed several problems with shallow_flash on on Cygwin

### DIFF
--- a/shallow_flash.sh
+++ b/shallow_flash.sh
@@ -255,7 +255,7 @@ function shallow_flash_gecko() {
     if [[ `uname` == "CYGWIN"* ]]; then
 	    # reset excutable attribute as is not supported on Cygwin
         echo "### Setting executable file attributes..." &&
-        XFILES=$(tar -tvf $GECKO_TAR_FILE | awk '$1 ~ /-.*x$/ {print "/system/" $NF}')
+        XFILES=$(tar -tvf $GECKO_TAR_FILE | awk '$1 ~ /^-.*x$/ {print "/system/" $NF}')
         echo $XFILES
         run_adb shell chmod 777 $XFILES	
         echo "### Setting attributes Done."


### PR DESCRIPTION
A couple of fixes that allow this to work on Windows + Cygwin

https://bugzilla.mozilla.org/show_bug.cgi?id=1069468
