### PR TITLE
Update shallow_flash.sh

### DIFF
--- a/shallow_flash.sh
+++ b/shallow_flash.sh
@@ -27,7 +27,8 @@ FLASH_GECKO_FILE=""
 NO_FTU=${NO_FTU:-false}
 # for other bash script tools call.
 case `uname` in
-    "Linux"|"CYGWIN"*) SP="";;
+    "Linux") SP=" ";;
+    "CYGWIN"*) SP="";;
     "Darwin") SP=" ";;
 esac
 


### PR DESCRIPTION
It affects me when I try to restore my profile. See this message:

<pre>
### Push Done.
### Restore Profile from /tmp/shallowflashprofile.kj9Dnrvn2KlI
### Waiting for device... please ensure it is connected, switched on and remote debugging is enabled in Gaia
Backup and restore Firefox OS profiles.

Usage:
  -b|--backup   backup user profile.
  -r|--restore  restore user profile.
  --sdcard  also backup/restore SD card.
  --no-reboot   do not reboot B2G after backup/restore.
  -p|--profile-dir  specify the profile folder. Default=./mozilla-profile
  -h|--help display help.
-p/tmp/shallowflashprofile.kj9Dnrvn2KlI is not a recognized option!
### Removing Profile under /tmp/shallowflashprofile.kj9Dnrvn2KlI
</pre>
