### PR TITLE
fix: make script running with -e option

### DIFF
--- a/shallow_flash.sh
+++ b/shallow_flash.sh
@@ -74,7 +74,9 @@ function make_sure() {
         echo -e "Gecko: $FLASH_GECKO_FILE "
     fi
     read -p "to your $ADB_DEVICE? [y/N]" isFlash
-    test "$isFlash" != "y"  && test "$isFlash" != "Y" && echo -e "bye bye." && exit 0
+
+    [ "y" = "$isFlash" ] || [ "Y" = "$isFlash" ] \
+        || { echo -e "bye bye." && exit 0 ; }
 }
 
 ## check the return code, exit if return code is not zero.


### PR DESCRIPTION
bash -e means stop on errors which is safer
so the tests had to be reversed to use OR vs AND operations

Signed-off-by: Philippe Coval rzr@gna.org
