### PR TITLE
bug fix: wrong re, use strict pattern instead

### DIFF
--- a/utilities/path_parser.py
+++ b/utilities/path_parser.py
@@ -140,7 +140,7 @@ class PathParser(object):
         target_url = base_url + build_src
         content = self._open_url(target_url)
         folder_pattern = re.compile(
-            '<a href="(\d+.)">.*</a>',  # Find folder name such like '2014/', '09/', ...
+            '<a href="(\d+.)">[0-9/]+</a>',  # Find folder name such like '2014/', '09/', ...
             re.DOTALL | re.MULTILINE)
         res = folder_pattern.findall(content)
         while res:  # If pattern not found, it should be in the build id list folder


### PR DESCRIPTION
RE now is too aggressive, which can match <a href="2014/">2014/..........<a href="2015/">......</a>, and will eventually match once.